### PR TITLE
Cancel statement to cancel queries in backed DB when query is cancelled in Hive/other engine

### DIFF
--- a/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/Constants.java
+++ b/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/Constants.java
@@ -17,14 +17,22 @@
 
 package org.apache.hadoop.hive.jdbc.storagehandler;
 
+import org.apache.hadoop.conf.Configuration;
+
 public final class Constants {
 
     public static final String LIST_COLUMNS = "columns";
     public static final String LIST_COLUMN_TYPES = "columns.types";
     public static final String LAZY_SPLIT = "mapred.jdbc.hive.lazy.split";
     public static final String PREDICATE_REQUIRED = "jdbc.storage.handler.predicate.required";
+    public static final String INPUT_FETCH_SIZE = "jdbc.storage.handler.input.fetch.size";
 
+    public static final int DEFAULT_INPUT_FETCH_SIZE = 1000;
     private Constants() {
+    }
+
+    public static int getInputFetchSize(Configuration conf) {
+        return conf.getInt(INPUT_FETCH_SIZE, 10000);
     }
 
 }

--- a/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/GenericDBRecordReader.java
+++ b/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/GenericDBRecordReader.java
@@ -1,0 +1,49 @@
+package org.apache.hadoop.hive.jdbc.storagehandler;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.lib.db.DBConfiguration;
+import org.apache.hadoop.mapreduce.lib.db.DBInputFormat;
+import org.apache.hadoop.mapreduce.lib.db.DBRecordReader;
+import org.apache.hadoop.mapreduce.lib.db.DBWritable;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.apache.hadoop.hive.jdbc.storagehandler.Constants.DEFAULT_INPUT_FETCH_SIZE;
+import static org.apache.hadoop.hive.jdbc.storagehandler.Constants.INPUT_FETCH_SIZE;
+/**
+ * Created by stagra on 8/14/15.
+ */
+public class GenericDBRecordReader<T extends DBWritable> extends DBRecordReader<T> {
+    final Configuration conf;
+    private static final Log LOG = LogFactory.getLog(GenericDBRecordReader.class);
+
+    public GenericDBRecordReader(DBInputFormat.DBInputSplit split, Class<T> inputClass, Configuration conf, Connection conn, DBConfiguration dbConfig, String cond, String[] fields, String table)
+            throws SQLException {
+        super(split, inputClass, conf, conn, dbConfig, cond, fields, table);
+        this.conf = conf;
+    }
+
+    @Override
+    protected ResultSet executeQuery(String query) throws SQLException {
+        this.statement = getConnection().prepareStatement(query,
+                ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+        statement.setFetchSize(conf.getInt(INPUT_FETCH_SIZE, DEFAULT_INPUT_FETCH_SIZE));
+        return statement.executeQuery();
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            statement.cancel();
+        } catch (SQLException e) {
+            // Ignore any errors in cancelling, this is not fatal
+            LOG.error("Could not cancel query: "  + this.getSelectQuery());
+        }
+        super.close();
+    }
+}

--- a/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/JdbcInputFormat.java
+++ b/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/JdbcInputFormat.java
@@ -59,6 +59,7 @@ public class JdbcInputFormat extends InputFormatWrapper {
     public InputSplit[] getSplits(JobConf job, int numSplits)
             throws IOException {
         JdbcSerDeHelper.setFilters(job);
+        job.setInt("mapred.map.tasks", numSplits);
         ((org.apache.hadoop.mapreduce.lib.db.DBInputFormat) realInputFormat)
                 .setConf(job);
         return super.getSplits(job, numSplits);


### PR DESCRIPTION
- Creates a GenericDBRecordReader which opens statement with fetch size of 1000(default, configurable)
- This RecordReader also cancels the statement on close() to cancel any incomplete query at backend

- This PR also has a small fix for creating correct number of splits as asked