### PR TITLE
Add support for hive2.3 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <version>0.0.7</version>
     <packaging>jar</packaging>
 
-    <name>duitang-hive-JDBC-storage-handler</name>
+    <name>qubole-hive-JDBC-storage-handler</name>
     <url>http://maven.apache.org</url>
 
     <properties>
@@ -42,12 +42,21 @@
             <version>3.1</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <version>2.8.0</version>
-        </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>hadoop-1</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-common</artifactId>
+                    <version>2.8.0</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
     <build>
 
@@ -90,7 +99,7 @@
                             <shadedPattern>qksh.shaded.org.joda</shadedPattern>
                         </relocation>
                     </relocations>
-                    <finalName>hive-jdbc-${project.version}</finalName>
+                    <finalName>qubole-hive-JDBC-final-${project.version}</finalName>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <version>0.0.7</version>
     <packaging>jar</packaging>
 
-    <name>qubole-hive-JDBC-storage-handler</name>
+    <name>duitang-hive-JDBC-storage-handler</name>
     <url>http://maven.apache.org</url>
 
     <properties>
@@ -19,15 +19,15 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-exec</artifactId>
-            <version>0.13.1</version>
+            <version>2.3.0</version>
             <scope>compile</scope>
-    </dependency>
-         <dependency>
-		 <groupId>org.apache.hive</groupId>
-		  <artifactId>hive-metastore</artifactId>
-		  <version>0.13.1</version>
-		  <scope>compile</scope>
-	  </dependency>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-metastore</artifactId>
+            <version>2.3.0</version>
+            <scope>compile</scope>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>
@@ -42,21 +42,12 @@
             <version>3.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>2.8.0</version>
+        </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>hadoop-1</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-core</artifactId>
-                    <version>1.2.1</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 
     <build>
 
@@ -99,7 +90,7 @@
                             <shadedPattern>qksh.shaded.org.joda</shadedPattern>
                         </relocation>
                     </relocations>
-                    <finalName>qubole-hive-JDBC-final-${project.version}</finalName>
+                    <finalName>hive-jdbc-${project.version}</finalName>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/HiveJdbcBridgeUtils.java
+++ b/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/HiveJdbcBridgeUtils.java
@@ -46,9 +46,6 @@ public class HiveJdbcBridgeUtils {
 		return result;
 	}
 
-	/**
-	 * @see org.apache.hadoop.hive.jdbc.Utils#hiveTypeToSqlType(String)
-	 */
 	private static int hiveTypeToSqlType(String hiveType) throws SerDeException {
 		final String lctype = hiveType.toLowerCase();
 		if ("string".equals(lctype)) {

--- a/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/JdbcDBInputSplit.java
+++ b/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/JdbcDBInputSplit.java
@@ -18,22 +18,8 @@ package org.apache.hadoop.hive.jdbc.storagehandler;
 
 import java.io.DataInput;
 import java.io.DataOutput;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Properties;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.serde2.SerDe;
-import org.apache.hadoop.hive.serde2.SerDeException;
-import org.apache.hadoop.hive.serde2.SerDeStats;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
-import org.apache.hadoop.hive.serde2.objectinspector.StructField;
-import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
-import org.apache.hadoop.io.Writable;
-import org.apache.hadoop.mapreduce.lib.db.DBInputFormat.DBInputSplit;
 import java.io.IOException;
 
 public class JdbcDBInputSplit extends org.apache.hadoop.mapreduce.lib.db.DBInputFormat.DBInputSplit {

--- a/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/JdbcOutputFormat.java
+++ b/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/JdbcOutputFormat.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hive.jdbc.storagehandler;
 
 import java.io.IOException;
 import java.util.Properties;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileSystem;
@@ -35,41 +36,41 @@ import org.apache.hadoop.mapred.lib.db.DBOutputFormat;
 import org.apache.hadoop.mapred.lib.db.DBOutputFormat.*;
 
 public class JdbcOutputFormat<V> extends DBOutputFormat<DbRecordWritable, V>
-		implements HiveOutputFormat<DbRecordWritable, V> {
+    implements HiveOutputFormat<DbRecordWritable, V> {
 
-	private static final Log LOG = LogFactory.getLog(JdbcOutputFormat.class);
-	private org.apache.hadoop.mapreduce.RecordWriter recordWriter;
-	private TaskAttemptContext taskContext;
+  private static final Log LOG = LogFactory.getLog(JdbcOutputFormat.class);
+  private org.apache.hadoop.mapreduce.RecordWriter recordWriter;
+  private TaskAttemptContext taskContext;
 
-	@Override
-	public void checkOutputSpecs(FileSystem filesystem, JobConf job)
-			throws IOException {
-	}
+  @Override
+  public void checkOutputSpecs(FileSystem filesystem, JobConf job)
+      throws IOException {
+  }
 
-	@Override
-	public RecordWriter getHiveRecordWriter(JobConf jobConf, Path finalOutPath,
-			Class<? extends Writable> valueClass, boolean isCompressed,
-			Properties tableProperties, Progressable progress)
-			throws IOException {
+  @Override
+  public RecordWriter getHiveRecordWriter(JobConf jobConf, Path finalOutPath,
+      Class<? extends Writable> valueClass, boolean isCompressed,
+      Properties tableProperties, Progressable progress)
+      throws IOException {
 
-		if (LOG.isDebugEnabled()) {
-			LOG.debug("jobConf: " + jobConf);
-			LOG.debug("tableProperties: " + tableProperties);
-		}
-		taskContext = ShimLoader.getHadoopShims().newTaskAttemptContext(
-				jobConf, null);
-		org.apache.hadoop.mapreduce.lib.db.DBOutputFormat delegate = new org.apache.hadoop.mapreduce.lib.db.DBOutputFormat();
-		recordWriter = delegate.getRecordWriter(taskContext);
-		// Wrapping DBRecordWriter in JdbcRecordWriter
-		return new JdbcRecordWriter(
-				(org.apache.hadoop.mapreduce.lib.db.DBOutputFormat.DBRecordWriter) recordWriter);
-	}
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("jobConf: " + jobConf);
+      LOG.debug("tableProperties: " + tableProperties);
+    }
+    taskContext = ShimLoader.getHadoopShims().newTaskAttemptContext(
+        jobConf, null);
+    org.apache.hadoop.mapreduce.lib.db.DBOutputFormat delegate = new org.apache.hadoop.mapreduce.lib.db.DBOutputFormat();
+    recordWriter = delegate.getRecordWriter(taskContext);
+    // Wrapping DBRecordWriter in JdbcRecordWriter
+    return new JdbcRecordWriter(
+        (org.apache.hadoop.mapreduce.lib.db.DBOutputFormat.DBRecordWriter) recordWriter);
+  }
 
-	@Override
-	public org.apache.hadoop.mapred.RecordWriter<DbRecordWritable, V> getRecordWriter(
-			FileSystem filesystem, JobConf job, String name,
-			Progressable progress) throws IOException {
-		throw new RuntimeException("Error: Hive should not invoke this method.");
-	}
+  @Override
+  public org.apache.hadoop.mapred.RecordWriter<DbRecordWritable, V> getRecordWriter(
+      FileSystem filesystem, JobConf job, String name,
+      Progressable progress) throws IOException {
+    throw new RuntimeException("Error: Hive should not invoke this method.");
+  }
 
 }

--- a/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/JdbcSerDe.java
+++ b/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/JdbcSerDe.java
@@ -23,7 +23,7 @@ import java.util.Properties;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -31,12 +31,11 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.io.Writable;
-import java.sql.*;
 
 /**
  * Serialize/Deserialize a tuple.
  */
-public class JdbcSerDe implements SerDe {
+public class JdbcSerDe extends AbstractSerDe {
     private static final Log LOG = LogFactory.getLog(JdbcSerDe.class);
 
     private DbRecordWritable cachedWritable;

--- a/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/JdbcSerDeHelper.java
+++ b/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/JdbcSerDeHelper.java
@@ -16,26 +16,14 @@
  */
 package org.apache.hadoop.hive.jdbc.storagehandler;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Properties;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.serde2.SerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
-import org.apache.hadoop.hive.serde2.SerDeStats;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
-import org.apache.hadoop.hive.serde2.objectinspector.StructField;
-import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
-import org.apache.hadoop.io.Writable;
 import java.sql.*;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.lib.db.DBConfiguration;
-import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.hive.ql.plan.TableScanDesc;
 
 public class JdbcSerDeHelper {

--- a/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/JdbcStorageHandler.java
+++ b/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/JdbcStorageHandler.java
@@ -21,7 +21,6 @@ import java.util.Properties;
 import java.util.*;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -32,24 +31,18 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.io.HiveOutputFormat;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.index.IndexSearchCondition;
-import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
 import org.apache.hadoop.hive.ql.index.IndexPredicateAnalyzer;
 import org.apache.hadoop.hive.ql.metadata.HiveStoragePredicateHandler;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.ql.security.authorization.DefaultHiveAuthorizationProvider;
 import org.apache.hadoop.hive.ql.security.authorization.HiveAuthorizationProvider;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.Deserializer;
-import org.apache.hadoop.hive.serde2.SerDe;
-import org.apache.hadoop.io.Writable;
-import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.lib.db.DBConfiguration;
 import org.apache.hadoop.hive.ql.metadata.DefaultStorageHandler;
-import org.apache.hadoop.hive.ql.plan.TableScanDesc;
-import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
-import org.apache.hadoop.hive.ql.plan.ExprNodeDescUtils;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 
 /**
@@ -196,7 +189,7 @@ public class JdbcStorageHandler extends DefaultStorageHandler implements
     }
 
     @Override
-    public Class<? extends SerDe> getSerDeClass() {
+    public Class<? extends AbstractSerDe> getSerDeClass() {
         return JdbcSerDe.class;
     }
 

--- a/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/exceptions/PredicateMissingException.java
+++ b/src/main/java/org/apache/hadoop/hive/jdbc/storagehandler/exceptions/PredicateMissingException.java
@@ -15,7 +15,6 @@
  */
 package org.apache.hadoop.hive.jdbc.storagehandler.exceptions;
 
-import java.io.IOException;
 
 /**
  * Created by stagra on 7/23/15.


### PR DESCRIPTION

1.hive upgrade after the original version can not support.
2. Removed a few unnecessary references.
After the rebuild package to modify, in Hadoop 2.8.0 and hive 2.3.0 environment to work properly.